### PR TITLE
Fix(pipeline.py)=Added dataset_location to bq_query_to_table component

### DIFF
--- a/pipelines/tensorflow/prediction/pipeline.py
+++ b/pipelines/tensorflow/prediction/pipeline.py
@@ -112,6 +112,7 @@ def tensorflow_pipeline(
         bq_client_project_id=project_id,
         destination_project_id=project_id,
         dataset_id=dataset_id,
+        dataset_location=dataset_location,
         query_job_config=json.dumps(dict(write_disposition="WRITE_TRUNCATE")),
     )
     ingest = bq_query_to_table(

--- a/pipelines/tensorflow/training/pipeline.py
+++ b/pipelines/tensorflow/training/pipeline.py
@@ -149,6 +149,7 @@ def tensorflow_pipeline(
         bq_client_project_id=project_id,
         destination_project_id=project_id,
         dataset_id=dataset_id,
+        dataset_location=dataset_location,
         query_job_config=json.dumps(dict(write_disposition="WRITE_TRUNCATE")),
     )
     ingest = bq_query_to_table(

--- a/pipelines/xgboost/prediction/pipeline.py
+++ b/pipelines/xgboost/prediction/pipeline.py
@@ -103,6 +103,7 @@ def xgboost_pipeline(
         bq_client_project_id=project_id,
         destination_project_id=project_id,
         dataset_id=dataset_id,
+        dataset_location=dataset_location,
         query_job_config=json.dumps(dict(write_disposition="WRITE_TRUNCATE")),
     )
     ingest = bq_query_to_table(

--- a/pipelines/xgboost/training/pipeline.py
+++ b/pipelines/xgboost/training/pipeline.py
@@ -141,6 +141,7 @@ def xgboost_pipeline(
         bq_client_project_id=project_id,
         destination_project_id=project_id,
         dataset_id=dataset_id,
+        dataset_location=dataset_location,
         query_job_config=json.dumps(dict(write_disposition="WRITE_TRUNCATE")),
     )
     ingest = bq_query_to_table(


### PR DESCRIPTION
Signed-off-by: alvaroazabal <alvaro.azabal@datatonic.com>

# Description

In this PR a bug has been fixed which used the EU dataset location by default, despite the user input. The four existing pipelines have been changed, by adding the dataset_location as an argument to the bq_query_to_table component. 
# How has this been tested?

Unit, pre-commit and end-to-end tests have run successfully

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have successfully run the E2E tests, and have included the links to the pipeline runs below
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated any relevant documentation to reflect my changes
- [x] I have assigned a reviewer and messaged them

# Pipeline run links:
https://console.cloud.google.com/vertex-ai/locations/europe-west4/pipelines/runs/tensorflow-train-pipeline-20220428172130?project=datatonic-vertex-pipeline-dev