### PR TITLE
ci: split e2e test from release pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,14 +225,17 @@ Remember that this configuration must be different for the two environments.
 
 ### CI/CD
 
-There are four CI/CD pipelines located under the [cloudbuild](cloudbuild) directory:
+There are five CI/CD pipelines located under the [cloudbuild](cloudbuild) directory:
 
 1. `pr-checks.yaml` - runs pre-commit checks and unit tests on the custom KFP components, and checks that the ML pipelines (training and prediction) can compile.
-2. `release.yaml` - Compiles the training and prediction pipelines, and copies the compiled pipelines, along with their respective `assets` directories, to Google Cloud Storage in the build / CI/CD environment. The Google Cloud Storage destination is namespaced using the git tag (see below). Following this, the E2E tests are run on the new compiled pipelines. Below is a diagram of how the files are published in each environment:
+2. `e2e-test.yaml` - copies the "assets" folders to the chosen GCS destination (versioned by git commit hash - see below) and runs end-to-end tests of the training and prediction pipeline.
+3. `release.yaml` - Compiles the training and prediction pipelines, and copies the compiled pipelines, along with their respective `assets` directories, to Google Cloud Storage in the build / CI/CD environment. The Google Cloud Storage destination is namespaced using the git tag (see below). Following this, the E2E tests are run on the new compiled pipelines.
+
+Below is a diagram of how the files are published in each environment in the `e2e-test.yaml` and `release.yaml` pipelines:
 
 ```
 . <-- GCS directory set by _PIPELINE_PUBLISH_GCS_PATH
-└── TAG_NAME <-- Git tag used for the release
+└── TAG_NAME or GIT COMMIT HASH <-- Git tag used for the release (release.yaml) OR git commit hash (e2e-test.yaml)
     ├── prediction
     │   ├── assets
     │   │   └── tfdv_schema_prediction.pbtxt
@@ -243,9 +246,8 @@ There are four CI/CD pipelines located under the [cloudbuild](cloudbuild) direct
         └── training.json   <-- compiled training pipeline
 ```
 
-3. `terraform-plan.yaml` - Checks the Terraform configuration under `envs/<env>` (i.e. `envs/test` or `envs/prod`), and produces a summary of any proposed changes that will be applied on merge to the main branch. Out of the box, this just includes Cloud Scheduler jobs used to schedule your ML pipelines.
-4. `terraform-apply.yaml` - Applies the Terraform configuration under `envs/<env>` (i.e. `envs/test` or `envs/prod`). Out of the box, this just includes Cloud Scheduler jobs used to schedule your ML pipelines.
- 
+4. `terraform-plan.yaml` - Checks the Terraform configuration under `envs/<env>` (i.e. `envs/test` or `envs/prod`), and produces a summary of any proposed changes that will be applied on merge to the main branch. Out of the box, this just includes Cloud Scheduler jobs used to schedule your ML pipelines.
+5. `terraform-apply.yaml` - Applies the Terraform configuration under `envs/<env>` (i.e. `envs/test` or `envs/prod`). Out of the box, this just includes Cloud Scheduler jobs used to schedule your ML pipelines.
 
 For more details on setting up CI/CD, see the [separate README](cloudbuild/README.md).
 

--- a/cloudbuild/e2e-test.yaml
+++ b/cloudbuild/e2e-test.yaml
@@ -1,0 +1,54 @@
+# Copyright 2022 Google LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+steps:
+
+  # Copy assets files to a new directory in GCS
+  # (via a new local directory)
+  # Directory name = git commit hash
+  - name: gcr.io/cloud-builders/gsutil
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        mkdir -p ${COMMIT_SHA}/training/assets && \
+        mkdir -p ${COMMIT_SHA}/prediction/assets && \
+        cp -r pipelines/${_PIPELINE_TEMPLATE}/training/assets ${COMMIT_SHA}/training/ && \
+        cp -r pipelines/${_PIPELINE_TEMPLATE}/prediction/assets ${COMMIT_SHA}/prediction/ && \
+        gsutil cp -r ${COMMIT_SHA} ${_PIPELINE_PUBLISH_GCS_PATH}
+
+  # Install Python deps
+  # Run end-to-end (E2E) pipeline tests on both pipelines
+  - name: python:3.7
+    entrypoint: /bin/sh
+    args:
+      - -c
+      - |
+        pip install pipenv && \
+        pipenv install --dev && \
+        make e2e-tests pipeline=training && \
+        make e2e-tests pipeline=prediction
+    env:
+      - VERTEX_LOCATION=${_TEST_VERTEX_LOCATION}
+      - VERTEX_PROJECT_ID=${_TEST_VERTEX_PROJECT_ID}
+      - VERTEX_SA_EMAIL=${_TEST_VERTEX_SA_EMAIL}
+      - VERTEX_CMEK_IDENTIFIER=${_TEST_VERTEX_CMEK_IDENTIFIER}
+      - VERTEX_NETWORK=${_TEST_VERTEX_NETWORK}
+      - PIPELINE_TEMPLATE=${_PIPELINE_TEMPLATE}
+      - PAYLOAD=${_TEST_PAYLOAD}
+      - VERTEX_PIPELINE_ROOT=${_TEST_VERTEX_PIPELINE_ROOT}
+      - PIPELINE_FILES_GCS_PATH=${_PIPELINE_PUBLISH_GCS_PATH}/${COMMIT_SHA}
+
+# Increase timeout to allow end-to-end (E2E) pipeline tests to run
+timeout: 18000s  # 5 hours

--- a/cloudbuild/release.yaml
+++ b/cloudbuild/release.yaml
@@ -29,7 +29,7 @@ steps:
 
   # Copy pipelines and files to a new directory in GCS
   # (via a new local directory)
-  # Directory name = git tag
+  # Directory name = git commit hash
   - name: gcr.io/cloud-builders/gsutil
     entrypoint: bash
     args:
@@ -43,27 +43,4 @@ steps:
         cp -r pipelines/${_PIPELINE_TEMPLATE}/prediction/assets ${TAG_NAME}/prediction/ && \
         gsutil cp -r ${TAG_NAME} ${_PIPELINE_PUBLISH_GCS_PATH}
 
-  # Install Python deps
-  # Run end-to-end (E2E) pipeline tests on both pipelines
-  - name: python:3.7
-    entrypoint: /bin/sh
-    args:
-      - -c
-      - |
-        pip install pipenv && \
-        pipenv install --dev && \
-        make e2e-tests pipeline=training && \
-        make e2e-tests pipeline=prediction
-    env:
-      - VERTEX_LOCATION=${_TEST_VERTEX_LOCATION}
-      - VERTEX_PROJECT_ID=${_TEST_VERTEX_PROJECT_ID}
-      - VERTEX_SA_EMAIL=${_TEST_VERTEX_SA_EMAIL}
-      - VERTEX_CMEK_IDENTIFIER=${_TEST_VERTEX_CMEK_IDENTIFIER}
-      - VERTEX_NETWORK=${_TEST_VERTEX_NETWORK}
-      - PIPELINE_TEMPLATE=${_PIPELINE_TEMPLATE}
-      - PAYLOAD=${_TEST_PAYLOAD}
-      - VERTEX_PIPELINE_ROOT=${_TEST_VERTEX_PIPELINE_ROOT}
-      - PIPELINE_FILES_GCS_PATH=${_PIPELINE_PUBLISH_GCS_PATH}/${TAG_NAME}
-
-# Increase timeout to allow end-to-end (E2E) pipeline tests to run
-timeout: 18000s  # 5 hours
+timeout: 1800s  # 30mins


### PR DESCRIPTION
<!-- 
Copyright 2022 Google LLC

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
 -->
# Description

Split the E2E test away from the the release pipeline, so that it can be run on pull request (in light of user feedback)