### PR TITLE
fix: save temporary tfma output plots to temporary dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,9 +172,3 @@ env.sh
 
 # Compiled pipeline components
 **/component.yaml
-
-# Files generated during unit testing
-# TODO remove these from .gitignore when addressing https://github.com/GoogleCloudPlatform/vertex-pipelines-end-to-end-samples/issues/29
-pipeline_components/evaluation/example_count.py
-pipeline_components/evaluation/plots_num_feat.html
-pipeline_components/evaluation/plots_overall.html

--- a/pipeline_components/evaluation/tests/test_custom_eval_metrics.py
+++ b/pipeline_components/evaluation/tests/test_custom_eval_metrics.py
@@ -52,7 +52,7 @@ def mock_download(tmpdir, local_path):
     shutil.copy(local_path, tmp_path)
 
 
-def test_calculate_custom_eval_metrics_overall(tmpdir):
+def test_calculate_custom_eval_metrics_overall(tmpdir, monkeypatch):
     """
     Test that calculate_eval_metrics produces the specified metrics (mean squared
     error, accuracy, and mean label) at an overall level.
@@ -63,6 +63,10 @@ def test_calculate_custom_eval_metrics_overall(tmpdir):
     Returns:
         None
     """
+
+    # use temporary directory as working directory for the test
+    monkeypatch.chdir(tmpdir)
+
     from evaluation.evaluation_metrics_tfma.component import calculate_eval_metrics
 
     # Import example_count module from assets directory
@@ -127,7 +131,7 @@ def test_calculate_custom_eval_metrics_overall(tmpdir):
     assert CLASS_NAME_TO_TEST in metrics_dict["Overall"]
 
 
-def test_calculate_custom_eval_metrics_with_slice(tmpdir):
+def test_calculate_custom_eval_metrics_with_slice(tmpdir, monkeypatch):
     """
     Test that calculate_eval_metrics produces the specified metrics (mean squared
     error, accuracy, and mean label) at an overall level + for slices.
@@ -138,6 +142,10 @@ def test_calculate_custom_eval_metrics_with_slice(tmpdir):
     Returns:
         None
     """
+
+    # use temporary directory as working directory for the test
+    monkeypatch.chdir(tmpdir)
+
     from evaluation.evaluation_metrics_tfma.component import calculate_eval_metrics
 
     # Import example_count module from assets directory

--- a/pipeline_components/evaluation/tests/test_eval_metrics.py
+++ b/pipeline_components/evaluation/tests/test_eval_metrics.py
@@ -18,7 +18,7 @@ import numpy as np
 from kfp.v2.dsl import Dataset, Artifact
 
 
-def test_calculate_eval_metrics_overall(tmpdir):
+def test_calculate_eval_metrics_overall(tmpdir, monkeypatch):
     """
     Test that calculate_eval_metrics produces the specified metrics (mean squared
     error, accuracy, and mean label) at an overall level.
@@ -29,6 +29,10 @@ def test_calculate_eval_metrics_overall(tmpdir):
     Returns:
         None
     """
+
+    # use temporary directory as working directory for the test
+    monkeypatch.chdir(tmpdir)
+
     from evaluation.evaluation_metrics_tfma.component import calculate_eval_metrics
 
     # Create a uri for the Metrics artifact which the kfp_component writes to
@@ -72,7 +76,7 @@ def test_calculate_eval_metrics_overall(tmpdir):
     assert "mean_label" in metrics_dict["Overall"]
 
 
-def test_calculate_eval_metrics_with_slice(tmpdir):
+def test_calculate_eval_metrics_with_slice(tmpdir, monkeypatch):
     """
     Test that calculate_eval_metrics produces the specified metrics (mean squared
     error, accuracy, and mean label) at an overall level + for slices.
@@ -83,6 +87,10 @@ def test_calculate_eval_metrics_with_slice(tmpdir):
     Returns:
         None
     """
+
+    # use temporary directory as working directory for the test
+    monkeypatch.chdir(tmpdir)
+
     from evaluation.evaluation_metrics_tfma.component import calculate_eval_metrics
 
     # Create a uri for the Metrics artifact which the kfp_component writes to
@@ -128,7 +136,7 @@ def test_calculate_eval_metrics_with_slice(tmpdir):
     assert "mean_label" in metrics_dict["Overall"]
 
 
-def test_visualise_eval_metrics_overall(tmpdir):
+def test_visualise_eval_metrics_overall(tmpdir, monkeypatch):
     """
     Test that calculate_eval_metrics produces the specified output plot
         ("plots_overall.html) at an overall level
@@ -139,6 +147,10 @@ def test_visualise_eval_metrics_overall(tmpdir):
     Returns:
         None
     """
+
+    # use temporary directory as working directory for the test
+    monkeypatch.chdir(tmpdir)
+
     from evaluation.evaluation_metrics_tfma.component import calculate_eval_metrics
 
     # Create a uri for the Metrics artifact which the kfp_component writes to
@@ -177,7 +189,7 @@ def test_visualise_eval_metrics_overall(tmpdir):
     assert view.path.endswith(".html")
 
 
-def test_visualise_eval_metrics_with_slice(tmpdir):
+def test_visualise_eval_metrics_with_slice(tmpdir, monkeypatch):
     """
     Test that calculate_eval_metrics produces the specified output plot
         ("plots_overall.html) at an overall level and at a slice level
@@ -189,6 +201,10 @@ def test_visualise_eval_metrics_with_slice(tmpdir):
     Returns:
         None
     """
+
+    # use temporary directory as working directory for the test
+    monkeypatch.chdir(tmpdir)
+
     from evaluation.evaluation_metrics_tfma.component import calculate_eval_metrics
 
     # Create a uri for the Metrics artifact which the kfp_component writes to


### PR DESCRIPTION
<!-- 
Copyright 2022 Google LLC

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
 -->
# Description

Fixes #29 
Unit tests for the evaluation component are run with the working directory monkey-patched to a temporary directory

# How has this been tested?

Unit tests still pass successfully, and files are not persisted

Equivalent PR [here](https://github.com/browningjp-datatonic/vertex-pipelines-end-to-end-samples/pull/4) to show that CI checks are successful (with the exception of e2e tests for xgboost pipeline which will be fixed by https://github.com/GoogleCloudPlatform/vertex-pipelines-end-to-end-samples/pull/30)

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have successfully run the E2E tests
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] New and existing unit tests pass locally with my changes
~~- [ ] I have updated any relevant documentation to reflect my changes~~
- [x] I have assigned a reviewer and messaged them