### PR TITLE
Relax TFDV schema

### DIFF
--- a/pipelines/pipelines/tensorflow/prediction/assets/tfdv_schema_serving.pbtxt
+++ b/pipelines/pipelines/tensorflow/prediction/assets/tfdv_schema_serving.pbtxt
@@ -80,7 +80,6 @@ feature {
 feature {
   name: "company"
   type: BYTES
-  domain: "company"
   presence {
     min_fraction: 1.0
     min_count: 1
@@ -104,48 +103,6 @@ feature {
       size: 1
     }
   }
-}
-string_domain {
-  name: "payment_type"
-  value: "Cash"
-  value: "Prcard"
-  value: "Credit Card"
-  value: "Mobile"
-  value: "Unknown"
-  value: "Dispute"
-  value: "No Charge"
-}
-string_domain {
-  name: "company"
-  value: "Top Cab"
-  value: "Sun Taxi"
-  value: "Flash Cab"
-  value: "U Taxicab"
-  value: "Globe Taxi"
-  value: "Setare Inc"
-  value: "5 Star Taxi"
-  value: "City Service"
-  value: "24 Seven Taxi"
-  value: "Leonard Cab Co"
-  value: "Chicago Taxicab"
-  value: "Petani Cab Corp"
-  value: "Medallion Leasin"
-  value: "Metro Jet Taxi A."
-  value: "Top Cab Affiliation"
-  value: "Chicago Independents"
-  value: "Koam Taxi Association"
-  value: "5062 - 34841 Sam Mestas"
-  value: "Choice Taxi Association"
-  value: "Taxi Affiliation Services"
-  value: "3556 - 36214 RC Andrews Cab"
-  value: "6574 - Babylon Express Inc."
-  value: "4053 - 40193 Adwar H. Nikola"
-  value: "Blue Ribbon Taxi Association"
-  value: "Taxicab Insurance Agency Llc"
-  value: "312 Medallion Management Corp"
-  value: "Taxicab Insurance Agency, LLC"
-  value: "Star North Taxi Management Llc"
-  value: "Patriot Taxi Dba Peace Taxi Associat"
 }
 default_environment: "TRAINING"
 default_environment: "SERVING"

--- a/pipelines/pipelines/tensorflow/training/assets/tfdv_schema_training.pbtxt
+++ b/pipelines/pipelines/tensorflow/training/assets/tfdv_schema_training.pbtxt
@@ -80,7 +80,6 @@ feature {
 feature {
   name: "company"
   type: BYTES
-  domain: "company"
   presence {
     min_fraction: 1.0
     min_count: 1
@@ -113,36 +112,4 @@ string_domain {
   value: "Unknown"
   value: "Dispute"
   value: "No Charge"
-}
-string_domain {
-  name: "company"
-  value: "Top Cab"
-  value: "Sun Taxi"
-  value: "Flash Cab"
-  value: "U Taxicab"
-  value: "Globe Taxi"
-  value: "Setare Inc"
-  value: "5 Star Taxi"
-  value: "City Service"
-  value: "24 Seven Taxi"
-  value: "Leonard Cab Co"
-  value: "Chicago Taxicab"
-  value: "Petani Cab Corp"
-  value: "Medallion Leasin"
-  value: "Metro Jet Taxi A."
-  value: "Top Cab Affiliation"
-  value: "Chicago Independents"
-  value: "Koam Taxi Association"
-  value: "5062 - 34841 Sam Mestas"
-  value: "Choice Taxi Association"
-  value: "Taxi Affiliation Services"
-  value: "3556 - 36214 RC Andrews Cab"
-  value: "6574 - Babylon Express Inc."
-  value: "4053 - 40193 Adwar H. Nikola"
-  value: "Blue Ribbon Taxi Association"
-  value: "Taxicab Insurance Agency Llc"
-  value: "312 Medallion Management Corp"
-  value: "Taxicab Insurance Agency, LLC"
-  value: "Star North Taxi Management Llc"
-  value: "Patriot Taxi Dba Peace Taxi Associat"
 }

--- a/pipelines/pipelines/xgboost/prediction/assets/tfdv_schema_serving.pbtxt
+++ b/pipelines/pipelines/xgboost/prediction/assets/tfdv_schema_serving.pbtxt
@@ -80,7 +80,6 @@ feature {
 feature {
   name: "company"
   type: BYTES
-  domain: "company"
   presence {
     min_fraction: 1.0
     min_count: 1
@@ -114,38 +113,6 @@ string_domain {
   value: "Unknown"
   value: "Dispute"
   value: "No Charge"
-}
-string_domain {
-  name: "company"
-  value: "Top Cab"
-  value: "Sun Taxi"
-  value: "Flash Cab"
-  value: "U Taxicab"
-  value: "Globe Taxi"
-  value: "Setare Inc"
-  value: "5 Star Taxi"
-  value: "City Service"
-  value: "24 Seven Taxi"
-  value: "Leonard Cab Co"
-  value: "Chicago Taxicab"
-  value: "Petani Cab Corp"
-  value: "Medallion Leasin"
-  value: "Metro Jet Taxi A."
-  value: "Top Cab Affiliation"
-  value: "Chicago Independents"
-  value: "Koam Taxi Association"
-  value: "5062 - 34841 Sam Mestas"
-  value: "Choice Taxi Association"
-  value: "Taxi Affiliation Services"
-  value: "3556 - 36214 RC Andrews Cab"
-  value: "6574 - Babylon Express Inc."
-  value: "4053 - 40193 Adwar H. Nikola"
-  value: "Blue Ribbon Taxi Association"
-  value: "Taxicab Insurance Agency Llc"
-  value: "312 Medallion Management Corp"
-  value: "Taxicab Insurance Agency, LLC"
-  value: "Star North Taxi Management Llc"
-  value: "Patriot Taxi Dba Peace Taxi Associat"
 }
 default_environment: "TRAINING"
 default_environment: "SERVING"

--- a/pipelines/pipelines/xgboost/training/assets/tfdv_schema_training.pbtxt
+++ b/pipelines/pipelines/xgboost/training/assets/tfdv_schema_training.pbtxt
@@ -80,7 +80,6 @@ feature {
 feature {
   name: "company"
   type: BYTES
-  domain: "company"
   presence {
     min_fraction: 1.0
     min_count: 1
@@ -113,36 +112,4 @@ string_domain {
   value: "Unknown"
   value: "Dispute"
   value: "No Charge"
-}
-string_domain {
-  name: "company"
-  value: "Top Cab"
-  value: "Sun Taxi"
-  value: "Flash Cab"
-  value: "U Taxicab"
-  value: "Globe Taxi"
-  value: "Setare Inc"
-  value: "5 Star Taxi"
-  value: "City Service"
-  value: "24 Seven Taxi"
-  value: "Leonard Cab Co"
-  value: "Chicago Taxicab"
-  value: "Petani Cab Corp"
-  value: "Medallion Leasin"
-  value: "Metro Jet Taxi A."
-  value: "Top Cab Affiliation"
-  value: "Chicago Independents"
-  value: "Koam Taxi Association"
-  value: "5062 - 34841 Sam Mestas"
-  value: "Choice Taxi Association"
-  value: "Taxi Affiliation Services"
-  value: "3556 - 36214 RC Andrews Cab"
-  value: "6574 - Babylon Express Inc."
-  value: "4053 - 40193 Adwar H. Nikola"
-  value: "Blue Ribbon Taxi Association"
-  value: "Taxicab Insurance Agency Llc"
-  value: "312 Medallion Management Corp"
-  value: "Taxicab Insurance Agency, LLC"
-  value: "Star North Taxi Management Llc"
-  value: "Patriot Taxi Dba Peace Taxi Associat"
 }


### PR DESCRIPTION
# Description

Remove domain for `company` column in public dataset. If the public dataset changes, the example pipelines fail. 
This effectively relaxes the data validation rules to allow a successful run of a newly cloned repository even if the contents of this column change. 
No (or less) manual changes to the schemas is expected in future changes as a result.

# How has this been tested?

Successfully ran validation components for all examples pipelines.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have successfully run the E2E tests, and have included the links to the pipeline runs below
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated any relevant documentation to reflect my changes
- [x] I have assigned a reviewer and messaged them

# Pipeline run links:

Will add if requested.