### PR TITLE
Fix a couple of links in README files

### DIFF
--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -27,8 +27,8 @@ Further useful documentation:
 - [Vertex AI](https://cloud.google.com/vertex-ai)
 
 The sections below provide a general description of the ML pipelines (training and prediction) for both the TensorFlow template and XGBoost template. These two templates are similar in most ways and a complete overview of their key differences are given in their own README files:
-- [TensorFlow pipelines README](tensorflow/README.md)
-- [XGBoost pipelines README](xgboost/README.md)
+- [TensorFlow pipelines README](pipelines/tensorflow/README.md)
+- [XGBoost pipelines README](pipelines/xgboost/README.md)
 
 ## Training Pipeline
 ### Prerequisites for training pipeline

--- a/pipelines/pipelines/tensorflow/README.md
+++ b/pipelines/pipelines/tensorflow/README.md
@@ -16,7 +16,7 @@ limitations under the License.
 # TensorFlow Pipelines
 
 ## Training pipeline
-The TensorFlow training pipeline can be found in [`training/pipeline.py`](training/pipeline.py). The training component [`train_tensorflow_model`](../kfp_components/tensorflow/train.py) is the main training component which contains the implementation of a TensorFlow Keras model.
+The TensorFlow training pipeline can be found in [`training/pipeline.py`](training/pipeline.py). The training component [`train_tensorflow_model`](../../../pipeline_components/_tensorflow/_tensorflow/train/component.py) is the main training component which contains the implementation of a TensorFlow Keras model.
 This component can then be wrapped in a custom kfp ContainerOp from [`google-cloud-pipeline-components`](https://github.com/kubeflow/pipelines/blob/master/components/google-cloud/google_cloud_pipeline_components/experimental/custom_job/utils.py) which submits a Vertex Training job with added flexibility for `machine_type`, `replica_count`, `accelerator_type` among other machine configurations. 
 
 ### Data
@@ -61,7 +61,7 @@ You can specify different hyperparameters through the `model_params` argument of
 - Evaluation metrics
 - Whether you want early stopping
 
-For a comprehensive list of options for the above hyperparameters, see the docstring in [`train.py`](../kfp_components/tensorflow/train.py). 
+For a comprehensive list of options for the above hyperparameters, see the docstring in [`train.py`](../../../pipeline_components/_tensorflow/_tensorflow/train/component.py). 
 
 ### Model artifacts
 A number of different model artifacts/objects are created by the training of the TensorFlow model. With these files, you can load the model into a new script (without any of the original training code) and run it or resume training from exactly where you left off. For more information, see [this](https://www.tensorflow.org/api_docs/python/tf/keras/models/save_model). 


### PR DESCRIPTION
<!-- 
Copyright 2022 Google LLC

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
 -->
# Description

I've fixed a couple of broken links in README files.