### PR TITLE
Update Tensorflow Prebuilt containers and saving method

### DIFF
--- a/pipelines/src/pipelines/tensorflow/training/assets/train_tf_model.py
+++ b/pipelines/src/pipelines/tensorflow/training/assets/train_tf_model.py
@@ -266,7 +266,7 @@ if not _is_chief(strategy):
 
 logging.info(f"Save model to: {args.model}")
 args.model.mkdir(parents=True)
-tf_model.save(str(args.model), save_format="tf")
+tf.saved_model.save(tf_model, args.model)
 
 logging.info(f"Save metrics to: {args.metrics}")
 eval_metrics = dict(zip(tf_model.metrics_names, tf_model.evaluate(test_ds)))

--- a/pipelines/src/pipelines/tensorflow/training/pipeline.py
+++ b/pipelines/src/pipelines/tensorflow/training/pipeline.py
@@ -227,8 +227,8 @@ def tensorflow_pipeline(
         project_id=project_id,
         project_location=project_location,
         model_display_name=model_name,
-        train_container_uri="europe-docker.pkg.dev/vertex-ai/training/tf-cpu.2-6:latest",  # noqa: E501
-        serving_container_uri="europe-docker.pkg.dev/vertex-ai/prediction/tf2-cpu.2-6:latest",  # noqa: E501
+        train_container_uri="europe-docker.pkg.dev/vertex-ai/training/tf-cpu.2-12.py310:latest",  # noqa: E501
+        serving_container_uri="europe-docker.pkg.dev/vertex-ai/prediction/tf2-cpu.2-12:latest",  # noqa: E501
         hparams=hparams,
         staging_bucket=staging_bucket,
         parent_model=existing_model,


### PR DESCRIPTION
<!-- 
Copyright 2022 Google LLC

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
 -->
# Description

This repository has outdated versions of the GCP pre-built containers for training and serving Tensorflow models (2.6 is no longer being patched and will be removed from GCP in September 2024), so I have updated them to use version 2.12, this also requires a saving approach to change, as models saved with `tf_model.save()` method are not picked up by the pre-built prediction container. This has been updated to `tf.saved_model.save()` which should work ok.

# How has this been tested?

I have made this change in an Org Repo that uses this template for training and serving tensorflow models, which ran successfully E2e. I don't personally have access to GCP or Vertex AI unfortunately!

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have successfully run the E2E tests, and have included the links to the pipeline runs below
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated any relevant documentation to reflect my changes
- [ ] I have assigned a reviewer and messaged them

# Pipeline run links:
